### PR TITLE
Add `git_sw` function

### DIFF
--- a/bin/git_sw
+++ b/bin/git_sw
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+if [ -z "$1" ]
+then
+  git branch | fzf-tmux | xargs git switch
+else
+  git switch "$@"
+fi

--- a/git/.gitconfig
+++ b/git/.gitconfig
@@ -6,7 +6,8 @@
 	st = status --short --branch
 	co = checkout
 	cob = checkout -b
-	br = branch
+  br = branch
+  sw = !git_sw
 	df = diff HEAD
 	pub = push origin -u HEAD
 	pub-sf = push --force staging HEAD:main

--- a/zsh/functions
+++ b/zsh/functions
@@ -1,0 +1,10 @@
+#
+# git
+#
+# completion for "git_sw" command in "$HOME"/.bin
+function _git_sw() {
+  for branch in $(git branch --format="%(refname:short)"); do
+    compadd "$branch"
+  done
+}
+compdef _git_sw git_sw


### PR DESCRIPTION
Wassim shared a few scripts that enables fuzzy-finding-switching of branches, which I _desperately_ need!

> Put this [shell script](https://github.com/wassimk/dotfiles/blob/main/bin/git_sw) in your bin PATH.
> Here is the [completion of branch](https://github.com/wassimk/dotfiles/blob/main/zsh/functions?plain=1#L13-L22) names for ZSH.
> And here is the [git alias](https://github.com/wassimk/dotfiles/blob/main/gitconfig?plain=1#L42) for git sw to use it.