### PR TITLE
Update Brewfiles and add manual downloads list

### DIFF
--- a/MANUAL_APPS.md
+++ b/MANUAL_APPS.md
@@ -1,0 +1,21 @@
+# Manual Downloads
+
+Apps not available through Brew, Cask, or the Mac App Store that need to be
+downloaded directly from the manufacturer's website.
+
+## Common
+
+<!-- Apps needed on all machines -->
+
+- **WeatherWise** — https://www.weatherwise.app — Weather app
+
+## Work
+
+<!-- Apps needed on work machines -->
+
+- **Wispr Flow** — https://www.wispr.com — AI dictation tool
+- **Shure MotiveMix** — https://www.shure.com/en-US/shop/software — Mixer app for MV7 microphone (replaces the deprecated ShurePlus MOTIV cask)
+
+## Personal
+
+<!-- Apps needed on personal machines -->

--- a/profiles/common/Brewfile
+++ b/profiles/common/Brewfile
@@ -4,8 +4,10 @@
 tap "github/gh"
 tap "jesseduffield/lazygit"
 tap "manaflow-ai/cmux"
+tap "oven-sh/bun"
 
 # `brew install ...`
+brew "bun"
 brew "direnv"
 brew "fd"
 brew "fzf"
@@ -24,6 +26,7 @@ brew "ripgrep"
 brew "the_silver_searcher"
 brew "pam-reattach"
 brew "tmux"
+brew "worktrunk"
 
 # `brew install --cask ...`
 cask "arc"

--- a/profiles/work/Brewfile
+++ b/profiles/work/Brewfile
@@ -2,12 +2,14 @@
 
 # `brew tap ...`
 tap "datadog-labs/pack"
+tap "wassimk/tap"
 tap "xcodesorg/made"
 
 # `brew install ...`
 brew "cairo" # Vector graphics library with cross-device output support - apparently needed for Prince Serverless
 brew "cocoapods" # Dependency manager for for Cocoa projects - CCA
 brew "datadog-labs/pack/pup" # Go-based command-line wrapper for easy interaction with Datadog APIs
+brew "granary" # Granola export tool
 brew "xcodes" # Best command-line tool to install and switch between multiple versions of Xcode
 
 # `brew install --cask ...`
@@ -19,8 +21,8 @@ cask "slack"
 cask "tuple"
 cask "zoom"
 cask "elgato-camera-hub"
+cask "elgato-control-center"
 cask "granola"
-cask "shureplus-motiv"
 
 # `mas install ...`
 mas "iA Presenter", id: 6746414429


### PR DESCRIPTION
## Summary
- **Common Brewfile**: Add bun (with oven-sh/bun tap) and worktrunk
- **Work Brewfile**: Add granary, elgato-control-center, and wassimk tap; remove deprecated shureplus-motiv (replaced by manual Shure MotiveMix download)
- **MANUAL_APPS.md**: New reference list for apps that must be downloaded directly from manufacturer websites (Wispr Flow, Shure MotiveMix, WeatherWise)

## Test plan
- [ ] Verify `brew bundle` runs cleanly with updated Brewfiles
- [ ] Confirm MANUAL_APPS.md links are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)