### PR TITLE
Add Claude Code statusline and custom skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 zsh/zshrc.local
 .tmux.conf.local
 .gitconfig.local
+agents/claude/settings.local.json
 bash/.fzf.bash
 zsh/.fzf.zsh
 .dot-version

--- a/agents/claude/settings.json
+++ b/agents/claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.sh"
+  },
   "cleanupPeriodDays": 365,
   "model": "opus",
   "enabledPlugins": {

--- a/agents/claude/settings.json
+++ b/agents/claude/settings.json
@@ -1,4 +1,17 @@
 {
+  "hooks": {
+    "Notification": [
+      {
+        "matcher": "permission_prompt|idle_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/opensessions-notify.sh"
+          }
+        ]
+      }
+    ]
+  },
   "statusLine": {
     "type": "command",
     "command": "~/.claude/statusline.sh"

--- a/agents/claude/settings.local.json.example
+++ b/agents/claude/settings.local.json.example
@@ -1,0 +1,5 @@
+{
+  "model": "opus[1m]",
+  "enabledPlugins": {},
+  "extraKnownMarketplaces": {}
+}

--- a/agents/claude/skills/commit/SKILL.md
+++ b/agents/claude/skills/commit/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: commit
+description: Create focused, well-crafted git commits. Use when the user asks to commit changes or says /commit.
+---
+
+Create one or more focused git commits from the current staged/unstaged changes.
+
+**Principles**
+
+- **Atomic commits** — each commit should represent one logical change. If the working tree contains multiple unrelated changes, split them into separate commits. Ask the user if the grouping is unclear.
+- **Subject line** — keep it under 72 characters. Short summary of *what* changed, written in imperative mood (e.g., "Add retry logic to upload handler").
+- **Body** — explain *why* the change was made, not *what* changed (the diff shows that). Provide context that someone reading `git log` in six months would find useful: motivation, trade-offs, things that were considered and rejected.
+- **No conventional commit prefixes** — don't use `feat:`, `fix:`, `chore:`, etc.
+- **Co-author line** — end every commit message with:
+  ```
+  Co-Authored-By: Claude <co-authored-by@anthropic.com>
+  ```
+
+**Steps**
+
+1. Run `git status` and `git diff` (staged + unstaged) to understand all current changes.
+2. Run `git log --oneline -5` to see recent commit style for reference.
+3. Analyze the changes and propose a grouping into atomic commits. If there's only one logical change, proceed directly. If there are multiple, show the user the proposed breakdown and get confirmation before committing.
+4. For each commit:
+   - Stage only the relevant files (`git add <specific files>`, never `git add -A` or `git add .`)
+   - Commit with a subject + body using a HEREDOC for formatting
+5. Run `git status` after all commits to confirm everything is clean (or show what remains uncommitted).
+
+**Do NOT**
+
+- Push to remote unless explicitly asked
+- Amend existing commits unless explicitly asked
+- Skip pre-commit hooks
+- Stage files that look like secrets (.env, credentials, tokens)

--- a/agents/claude/skills/create-pr/SKILL.md
+++ b/agents/claude/skills/create-pr/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: create-pr
+description: Create a GitHub pull request with a narrative description. Use when the user asks to open/create a PR or says /create-pr.
+---
+
+Create a GitHub pull request for the current branch.
+
+**Principles**
+
+- **Title** — short, clear summary of the purpose of the PR. Under 72 characters.
+- **Narrative over bullet points** — describe the changes in prose, not lists. The commits and diff show *what* changed; the PR description explains *what* and *why* at a higher level.
+- **Keep it concise** — a few sentences is usually enough. Don't restate the diff.
+
+**Template**
+
+Use only the **What** and **Why** sections:
+
+```markdown
+## What
+
+A brief narrative explanation of what this PR does.
+
+## Why
+
+The motivation, context, or problem that led to these changes.
+```
+
+Omit the How, Notes, and Screenshots sections unless the user specifically asks for them or the changes genuinely warrant it (e.g., a UI change where a screenshot helps).
+
+End the body with:
+```
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+**Steps**
+
+1. Run `git status` to check for uncommitted changes. If there are unstaged changes, ask the user if they want to commit first.
+2. Run `git log` and `git diff main...HEAD` (or the appropriate base branch) to understand the full set of changes on the branch.
+3. Check if the branch has been pushed to remote. If not, push with `-u`.
+4. Draft the PR title and body, then create it with `gh pr create`.
+5. Return the PR URL to the user.
+
+**Do NOT**
+
+- Add a test plan section
+- Use bullet-point lists of changes
+- Include the Co-Authored-By line in the PR body (that's for commits only)


### PR DESCRIPTION
## What

Adds the statusline configuration to Claude Code settings and two new custom skills: `/commit` for crafting focused atomic commits, and `/create-pr` for generating narrative-style pull requests.

## Why

The statusline enables tmux integration for Claude Code sessions. The skills codify commit and PR preferences — short imperative subjects, why-focused commit bodies, and What/Why narrative PR descriptions — so they're consistent across machines and sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)